### PR TITLE
Phase 1 core loop: speak → distill → reveal → chronicle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,13 +40,17 @@ jobs:
         if: steps.creds.outputs.available == 'true'
       - name: Deploy to Cloud Run
         if: steps.creds.outputs.available == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          FAKE="true"
+          if [ -n "$OPENAI_API_KEY" ]; then FAKE="false"; fi
           gcloud run deploy sentimental-api-v2 \
             --source api \
             --region europe-west1 \
             --project sentimental-f95e6 \
             --allow-unauthenticated \
-            --set-env-vars "ENVIRONMENT=production,APP_VERSION=${GITHUB_SHA::8}" \
+            --set-env-vars "ENVIRONMENT=production,APP_VERSION=${GITHUB_SHA::8},STORAGE_MODE=gcs,FAKE_PROVIDERS=${FAKE},OPENAI_API_KEY=${OPENAI_API_KEY}" \
             --quiet
 
   web:
@@ -71,8 +75,8 @@ jobs:
       - name: Build
         if: steps.creds.outputs.available == 'true'
         working-directory: web
-        run: npm ci && npm run build
-      - name: Deploy to Firebase Hosting
+        run: npm ci && npm run build && rm -rf ../deploy/dist && cp -r dist ../deploy/dist
+      - name: Deploy to Firebase Hosting (site sentimentalapp-test)
         if: steps.creds.outputs.available == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -80,3 +84,5 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SA_KEY }}
           channelId: live
           projectId: sentimental-f95e6
+          entryPoint: deploy
+          target: sentimentalapp-test

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ public/static/css/.env
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Deploy build staging
+deploy/dist/

--- a/api/app/assets/daily_questions.json
+++ b/api/app/assets/daily_questions.json
@@ -1,0 +1,74 @@
+{
+  "universal": [
+    {
+      "id": "uq-01",
+      "en": "Tell me about a moment from this year you keep coming back to.",
+      "et": "Räägi mulle ühest selle aasta hetkest, mille juurde sa aina tagasi tuled."
+    },
+    {
+      "id": "uq-02",
+      "en": "Who surprised you recently — and what did they do?",
+      "et": "Kes sind hiljuti üllatas — ja millega?"
+    },
+    {
+      "id": "uq-03",
+      "en": "What's something small that made today different from yesterday?",
+      "et": "Mis väike asi tegi tänase päeva eilsest erinevaks?"
+    },
+    {
+      "id": "uq-04",
+      "en": "Tell me about a place you can picture down to the smallest detail.",
+      "et": "Räägi mulle kohast, mida sa mäletad pisima detailini."
+    },
+    {
+      "id": "uq-05",
+      "en": "What did you almost say to someone today, but didn't?",
+      "et": "Mida sa täna oleksid peaaegu kellelegi öelnud, aga jätsid ütlemata?"
+    },
+    {
+      "id": "uq-06",
+      "en": "What's a smell or sound that takes you straight back somewhere?",
+      "et": "Mis lõhn või heli viib su otsejoones kuhugi tagasi?"
+    },
+    {
+      "id": "uq-07",
+      "en": "Tell me about something you did recently that younger you wouldn't believe.",
+      "et": "Räägi millestki hiljutisest, mida noorem sina ei usuks."
+    },
+    {
+      "id": "uq-08",
+      "en": "What conversation from this week is still running in your head?",
+      "et": "Milline selle nädala vestlus käib sul ikka veel peas?"
+    },
+    {
+      "id": "uq-09",
+      "en": "What are you quietly proud of right now?",
+      "et": "Mille üle sa praegu vaikselt uhke oled?"
+    },
+    {
+      "id": "uq-10",
+      "en": "Tell me about an object you own that has a story behind it.",
+      "et": "Räägi mulle ühest oma asjast, millel on lugu taga."
+    },
+    {
+      "id": "uq-11",
+      "en": "What's something you're in the middle of figuring out?",
+      "et": "Mis on see asi, mille üle sa parasjagu pead murrad?"
+    },
+    {
+      "id": "uq-12",
+      "en": "Who do you miss, and what would you tell them right now?",
+      "et": "Kellest sa puudust tunned ja mida sa talle praegu ütleksid?"
+    },
+    {
+      "id": "uq-13",
+      "en": "Tell me about the last time you laughed properly.",
+      "et": "Räägi mulle viimasest korrast, kui sa päriselt naersid."
+    },
+    {
+      "id": "uq-14",
+      "en": "What's a tiny ritual of yours that nobody else knows about?",
+      "et": "Mis on sinu väike rituaal, millest keegi teine ei tea?"
+    }
+  ]
+}

--- a/api/app/clients/media.py
+++ b/api/app/clients/media.py
@@ -1,0 +1,51 @@
+"""Media blob storage: local disk for dev/test, GCS for deployment."""
+
+from pathlib import Path
+from typing import Protocol
+from uuid import uuid4
+
+from app.core.config import get_settings
+
+
+class MediaStore(Protocol):
+    def save(self, data: bytes, suffix: str) -> str:
+        """Persist bytes, return an opaque storage ref."""
+        ...
+
+    def read(self, ref: str) -> bytes: ...
+
+
+class LocalMediaStore:
+    def __init__(self, root: str | None = None) -> None:
+        self._root = Path(root or get_settings().upload_dir)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def save(self, data: bytes, suffix: str) -> str:
+        name = f"{uuid4().hex}{suffix}"
+        (self._root / name).write_bytes(data)
+        return f"local://{name}"
+
+    def read(self, ref: str) -> bytes:
+        return (self._root / ref.removeprefix("local://")).read_bytes()
+
+
+class GcsMediaStore:
+    def __init__(self) -> None:
+        from google.cloud import storage  # type: ignore[attr-defined]
+
+        self._bucket = storage.Client().bucket(get_settings().gcs_bucket)
+
+    def save(self, data: bytes, suffix: str) -> str:
+        name = f"v2/entries/{uuid4().hex}{suffix}"
+        self._bucket.blob(name).upload_from_string(data)
+        return f"gs://{get_settings().gcs_bucket}/{name}"
+
+    def read(self, ref: str) -> bytes:
+        name = ref.removeprefix(f"gs://{get_settings().gcs_bucket}/")
+        return self._bucket.blob(name).download_as_bytes()
+
+
+def get_media_store() -> MediaStore:
+    if get_settings().storage_mode == "gcs":
+        return GcsMediaStore()
+    return LocalMediaStore()

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -20,6 +20,19 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     fal_key: str = ""
 
+    # Media storage: "local" writes under upload_dir (dev/test); "gcs" uses the bucket.
+    storage_mode: str = "local"
+    upload_dir: str = "var/uploads"
+    gcs_bucket: str = "sentimental-audio-uploads"
+
+    # Model choices (override per environment without code changes).
+    llm_model: str = "gpt-4o-mini"
+    transcribe_model: str = "gpt-4o-mini-transcribe"
+    openai_base_url: str = "https://api.openai.com/v1"
+
+    # Per-user budget guardrail (docs/plan/07): max entries distilled per day.
+    daily_entry_limit: int = 20
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/api/app/core/recommend.py
+++ b/api/app/core/recommend.py
@@ -1,18 +1,53 @@
 """Rule-based format recommendation v1 (recommend-format@v1 becomes an LLM
-asset later; rules first per docs/plan/01 step 5)."""
+asset later; rules first per docs/plan/01 step 5). Reasons are bilingual so
+the UI can match the story's language."""
 
-_BY_TONE: dict[str, tuple[str, str]] = {
-    "joy": ("song", "this one has a melody in it already"),
-    "bittersweet": ("song", "this wants to be a song — the kind you play twice"),
-    "grief": ("story", "some things just want to be said plainly and kept"),
-    "pride": ("film", "this deserves to be seen, not just read"),
-    "calm": ("story", "a quiet page for a quiet moment"),
-    "longing": ("song", "longing always sings better than it speaks"),
-    "fear": ("story", "naming it on a page makes it smaller"),
-    "wonder": ("film", "this one needs pictures"),
+_BY_TONE: dict[str, tuple[str, str, str]] = {
+    "joy": (
+        "song",
+        "this one has a melody in it already",
+        "selles on juba viis sees",
+    ),
+    "bittersweet": (
+        "song",
+        "this wants to be a song — the kind you play twice",
+        "see tahab olla laul — selline, mida kuulad kaks korda",
+    ),
+    "grief": (
+        "story",
+        "some things just want to be said plainly and kept",
+        "mõned asjad tahavad lihtsalt öeldud ja hoitud saada",
+    ),
+    "pride": (
+        "film",
+        "this deserves to be seen, not just read",
+        "see väärib nägemist, mitte ainult lugemist",
+    ),
+    "calm": (
+        "story",
+        "a quiet page for a quiet moment",
+        "vaikne lehekülg vaikse hetke jaoks",
+    ),
+    "longing": (
+        "song",
+        "longing always sings better than it speaks",
+        "igatsus laulab alati paremini, kui räägib",
+    ),
+    "fear": (
+        "story",
+        "naming it on a page makes it smaller",
+        "lehele kirjutatuna muutub see väiksemaks",
+    ),
+    "wonder": (
+        "film",
+        "this one needs pictures",
+        "see vajab pilte",
+    ),
 }
+
+_DEFAULT = ("story", "a page of your chronicle", "lehekülg sinu kroonikas")
 
 
 def recommend_format(signature: dict) -> dict:
-    fmt, reason = _BY_TONE.get(signature.get("tone", ""), ("story", "a page of your chronicle"))
-    return {"format": fmt, "reason": reason}
+    fmt, reason_en, reason_et = _BY_TONE.get(signature.get("tone", ""), _DEFAULT)
+    return {"format": fmt, "reason": {"en": reason_en, "et": reason_et}}

--- a/api/app/core/recommend.py
+++ b/api/app/core/recommend.py
@@ -1,0 +1,18 @@
+"""Rule-based format recommendation v1 (recommend-format@v1 becomes an LLM
+asset later; rules first per docs/plan/01 step 5)."""
+
+_BY_TONE: dict[str, tuple[str, str]] = {
+    "joy": ("song", "this one has a melody in it already"),
+    "bittersweet": ("song", "this wants to be a song — the kind you play twice"),
+    "grief": ("story", "some things just want to be said plainly and kept"),
+    "pride": ("film", "this deserves to be seen, not just read"),
+    "calm": ("story", "a quiet page for a quiet moment"),
+    "longing": ("song", "longing always sings better than it speaks"),
+    "fear": ("story", "naming it on a page makes it smaller"),
+    "wonder": ("film", "this one needs pictures"),
+}
+
+
+def recommend_format(signature: dict) -> dict:
+    fmt, reason = _BY_TONE.get(signature.get("tone", ""), ("story", "a page of your chronicle"))
+    return {"format": fmt, "reason": reason}

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from fastapi import FastAPI
 
 from app.core.config import get_settings
-from app.routes import demo, health, internal_tasks
+from app.routes import demo, entries, health, internal_tasks, stories
 
 logging.basicConfig(
     level=logging.INFO,
@@ -23,4 +23,6 @@ app = FastAPI(
 
 app.include_router(health.router)
 app.include_router(demo.router, prefix="/api")
+app.include_router(entries.router, prefix="/api")
+app.include_router(stories.router, prefix="/api")
 app.include_router(internal_tasks.router)

--- a/api/app/pipelines/distill.py
+++ b/api/app/pipelines/distill.py
@@ -60,7 +60,7 @@ def _parse_json(text: str) -> dict:
 
 def _distill(run: PipelineRun) -> dict:
     transcript = (run.step("transcribe").output or {})["text"]
-    prompt = load_prompt("distill@v1")
+    prompt = load_prompt("distill@v2")
     job = get_provider("llm").submit(
         {
             "prompt": prompt.render(transcript=transcript),

--- a/api/app/pipelines/distill.py
+++ b/api/app/pipelines/distill.py
@@ -1,0 +1,152 @@
+"""The distill pipeline: entry (voice or text) -> story (docs/plan/01 step 3).
+
+Steps:
+  transcribe  voice entries only; text entries seed the transcript directly
+  distill     LLM renders distill@v1 -> {title, story, language, signature}
+  safety      crisis screen (crisis-detect@v1); flags, never blocks
+  finalize    persists the story doc and links it to the entry
+"""
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.clients.media import get_media_store
+from app.core.recommend import recommend_format
+from app.pipelines.models import PipelineRun, PipelineStep
+from app.pipelines.runner import register_pipeline
+from app.prompts.loader import load_prompt
+from app.providers.registry import get_provider
+from app.stores import collections
+
+PIPELINE_TYPE = "distill"
+
+ALLOWED_TONES = {"joy", "bittersweet", "grief", "pride", "calm", "longing", "fear", "wonder"}
+
+
+def _entry(run: PipelineRun) -> dict:
+    seed = run.step("seed").output or {}
+    entry = collections.entries().get(seed["entry_id"])
+    if entry is None:
+        raise RuntimeError(f"Entry {seed['entry_id']} not found")
+    return entry
+
+
+def _seed(run: PipelineRun) -> dict:
+    return run.step("seed").output or {}
+
+
+def _transcribe(run: PipelineRun) -> dict:
+    entry = _entry(run)
+    if entry["source"] == "text":
+        return {"text": entry["transcript"], "language": entry.get("language", "")}
+    audio = get_media_store().read(entry["audio_ref"])
+    job = get_provider("transcribe").submit(
+        {
+            "audio": audio,
+            "mime_type": entry["mime_type"],
+            "duration_ms": entry.get("duration_ms", 120_000),
+        }
+    )
+    run.step("transcribe").cost_estimate_usd = job.cost_estimate_usd
+    return job.output or {}
+
+
+def _parse_json(text: str) -> dict:
+    # Models occasionally wrap JSON in code fences despite instructions.
+    cleaned = text.strip().removeprefix("```json").removeprefix("```").removesuffix("```")
+    return json.loads(cleaned)
+
+
+def _distill(run: PipelineRun) -> dict:
+    transcript = (run.step("transcribe").output or {})["text"]
+    prompt = load_prompt("distill@v1")
+    job = get_provider("llm").submit(
+        {
+            "prompt": prompt.render(transcript=transcript),
+            "purpose": "distill",
+            "temperature": float(prompt.meta.get("temperature", "0.7")),
+        }
+    )
+    run.step("distill").cost_estimate_usd = job.cost_estimate_usd
+    parsed = _parse_json((job.output or {})["text"])
+
+    signature = parsed.get("signature", {})
+    if signature.get("tone") not in ALLOWED_TONES:
+        signature["tone"] = "calm"
+    return {
+        "title": str(parsed["title"]).strip(),
+        "story": str(parsed["story"]).strip(),
+        "language": parsed.get("language", ""),
+        "signature": {
+            "tone": signature["tone"],
+            "themes": [str(t) for t in signature.get("themes", [])][:3],
+            "people": [str(p) for p in signature.get("people", [])][:5],
+        },
+        "prompt_ref": prompt.ref,
+    }
+
+
+def _safety(run: PipelineRun) -> dict:
+    transcript = (run.step("transcribe").output or {})["text"]
+    prompt = load_prompt("crisis-detect@v1")
+    job = get_provider("llm").submit(
+        {"prompt": prompt.render(transcript=transcript), "purpose": "crisis", "temperature": 0.0}
+    )
+    run.step("safety").cost_estimate_usd = job.cost_estimate_usd
+    try:
+        parsed = _parse_json((job.output or {})["text"])
+        return {"flag": bool(parsed.get("flag")), "reason": str(parsed.get("reason", ""))}
+    except (json.JSONDecodeError, KeyError):
+        return {"flag": False, "reason": ""}  # screening must never break the loop
+
+
+def _finalize(run: PipelineRun) -> dict:
+    entry = _entry(run)
+    distilled = run.step("distill").output or {}
+    safety = run.step("safety").output or {}
+    story_id = uuid4().hex
+    story = {
+        "id": story_id,
+        "user_id": run.user_id,
+        "entry_id": entry["id"],
+        "title": distilled["title"],
+        "story": distilled["story"],
+        "language": distilled["language"],
+        "signature": distilled["signature"],
+        "recommendation": recommend_format(distilled["signature"]),
+        "support_flag": safety.get("flag", False),
+        "prompt_ref": distilled.get("prompt_ref", ""),
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    collections.stories().set(story_id, story)
+    entry["story_id"] = story_id
+    entry["status"] = "done"
+    collections.entries().set(entry["id"], entry)
+    return {"story_id": story_id}
+
+
+def new_distill_run(user_id: str, entry_id: str) -> PipelineRun:
+    return PipelineRun(
+        type=PIPELINE_TYPE,
+        user_id=user_id,
+        steps=[
+            PipelineStep(name="seed", output={"entry_id": entry_id}),
+            PipelineStep(name="transcribe"),
+            PipelineStep(name="distill"),
+            PipelineStep(name="safety"),
+            PipelineStep(name="finalize"),
+        ],
+    )
+
+
+register_pipeline(
+    PIPELINE_TYPE,
+    {
+        "seed": _seed,
+        "transcribe": _transcribe,
+        "distill": _distill,
+        "safety": _safety,
+        "finalize": _finalize,
+    },
+)

--- a/api/app/prompts/assets/crisis-detect@v1.md
+++ b/api/app/prompts/assets/crisis-detect@v1.md
@@ -1,0 +1,21 @@
+---
+name: crisis-detect
+version: 1
+model_role: safety screen
+temperature: 0.0
+owner: founder
+changelog: initial version; runs on every entry per docs/plan/01 guardrails
+---
+You screen a private journal entry for acute crisis signals. You are NOT a
+moderator and NOT a therapist; you only decide whether the app should gently
+show support resources alongside the story.
+
+Flag ONLY acute signals: stated intent or ideation of self-harm or suicide,
+ongoing abuse or immediate danger. Ordinary sadness, grief, anger, dark humor
+or processing of past hardship must NOT be flagged.
+
+OUTPUT — strict JSON, nothing else:
+{"flag": true/false, "reason": "one short sentence, empty string if false"}
+
+ENTRY:
+{transcript}

--- a/api/app/prompts/assets/distill@v1.md
+++ b/api/app/prompts/assets/distill@v1.md
@@ -1,0 +1,44 @@
+---
+name: distill
+version: 1
+model_role: story extraction
+temperature: 0.7
+owner: founder
+changelog: initial version per docs/plan/06 part B
+---
+You are the quiet craftsperson of a private story studio. A person has just
+spoken freely about something from their life. Your job is to distill what
+they said into a short, true, beautifully written story.
+
+PRIME DIRECTIVE — TRUTH OVER POLISH:
+Never invent biographical facts. No new people, places, events, dates,
+objects, or dialogue that the speaker did not mention. Style is free; facts
+are sacred. If the material is thin, write a shorter story — never pad with
+invention.
+
+VOICE:
+- Preserve the speaker's own idiom and specific images. If they said "she
+  always burned the rice", that exact image belongs in the story.
+- First person, as the speaker. Their vocabulary, elevated only in rhythm
+  and clarity — not replaced with generic eloquence.
+- Find the agency: where the material allows, let the narrator's choice or
+  growth surface naturally. But mundane entries are allowed to stay mundane;
+  forced uplift reads as fake.
+
+LANGUAGE:
+Write the story in the language the person spoke. Estonian in, Estonian out.
+
+OUTPUT — strict JSON, nothing else:
+{
+  "title": "evocative, max 6 words, no clichés (no 'A Journey of...', 'Lessons in...')",
+  "story": "the distilled story, 120-350 words, paragraphs separated by \n\n",
+  "language": "two-letter code of the story language",
+  "signature": {
+    "tone": "one of: joy | bittersweet | grief | pride | calm | longing | fear | wonder",
+    "themes": ["1-3 short lowercase theme words"],
+    "people": ["names or roles the speaker mentioned, e.g. 'ema', 'my brother'"]
+  }
+}
+
+TRANSCRIPT OF WHAT THEY SAID:
+{transcript}

--- a/api/app/prompts/assets/distill@v2.md
+++ b/api/app/prompts/assets/distill@v2.md
@@ -1,0 +1,53 @@
+---
+name: distill
+version: 2
+model_role: story extraction
+temperature: 0.6
+owner: founder
+changelog: v2 — harden anti-invention (no added feelings/conclusions), forbid closing moral, enforce output language for title/themes/people, founder review 2026-07-09
+---
+You are the quiet craftsperson of a private story studio. A person has just
+spoken freely about something from their life. Your job is to distill what
+they said into a short, true, beautifully written story.
+
+PRIME DIRECTIVE — TRUTH OVER POLISH:
+Never invent. This covers more than facts:
+- No new people, places, events, dates, objects, or dialogue.
+- No feelings, hopes, intentions, realizations, or conclusions the speaker
+  did not themselves express. If they said "I thought I should visit more
+  often", you may keep exactly that — you may NOT extend it into hopes,
+  promises, or life lessons.
+- No closing moral, no summary sentence, no "I understood that...". If the
+  speaker ended mid-thought, the story is allowed to end mid-thought. An
+  honest unresolved ending is better than a manufactured resolution.
+If the material is thin, write a shorter story — never pad.
+
+VOICE:
+- Preserve the speaker's own idiom and specific images. If they said "she
+  always burned the rice", that exact image belongs in the story.
+- First person, as the speaker. Their vocabulary, elevated only in rhythm
+  and clarity — not replaced with generic eloquence.
+- Cut filler and repetition; reorder only for clarity. Compression is your
+  craft, addition is your failure.
+
+LANGUAGE — applies to EVERY human-readable field:
+The story, the title, the themes, and the people labels must all be in the
+language the person spoke. Estonian in → Estonian title, Estonian themes,
+Estonian people labels ("vanaema", not "grandmother"). Only the "tone" and
+"language" fields use the fixed English codes below, because they are
+machine-read.
+
+OUTPUT — strict JSON, nothing else:
+{
+  "title": "evocative, max 6 words, in the story's language, no clichés",
+  "story": "the distilled story, 100-300 words, paragraphs separated by \n\n",
+  "language": "two-letter code of the story language",
+  "signature": {
+    "tone": "one of: joy | bittersweet | grief | pride | calm | longing | fear | wonder",
+    "themes": ["1-3 short lowercase theme words IN THE STORY'S LANGUAGE"],
+    "people": ["names or roles exactly as the speaker said them"]
+  }
+}
+
+TRANSCRIPT OF WHAT THEY SAID:
+{transcript}

--- a/api/app/prompts/loader.py
+++ b/api/app/prompts/loader.py
@@ -1,0 +1,40 @@
+"""Prompt assets: versioned markdown files with front-matter (docs/plan/06)."""
+
+from functools import lru_cache
+from pathlib import Path
+
+ASSETS_DIR = Path(__file__).parent / "assets"
+
+
+class PromptAsset:
+    def __init__(self, name: str, version: int, meta: dict[str, str], template: str) -> None:
+        self.name = name
+        self.version = version
+        self.meta = meta
+        self.template = template
+
+    @property
+    def ref(self) -> str:
+        return f"{self.name}@v{self.version}"
+
+    def render(self, **kwargs: str) -> str:
+        text = self.template
+        for key, value in kwargs.items():
+            text = text.replace("{" + key + "}", value)
+        return text
+
+
+@lru_cache
+def load_prompt(ref: str) -> PromptAsset:
+    """Load e.g. 'distill@v1' from assets/distill@v1.md."""
+    path = ASSETS_DIR / f"{ref}.md"
+    raw = path.read_text(encoding="utf-8")
+    if not raw.startswith("---"):
+        raise ValueError(f"Prompt {ref} is missing front-matter")
+    _, front, body = raw.split("---", 2)
+    meta: dict[str, str] = {}
+    for line in front.strip().splitlines():
+        key, _, value = line.partition(":")
+        meta[key.strip()] = value.strip()
+    name, _, version = ref.partition("@v")
+    return PromptAsset(name, int(version), meta, body.strip())

--- a/api/app/providers/openai.py
+++ b/api/app/providers/openai.py
@@ -1,0 +1,79 @@
+"""Real OpenAI providers: transcription + chat completion (sync, called from workers)."""
+
+from uuid import uuid4
+
+import httpx
+
+from app.core.config import get_settings
+from app.providers.base import JobStatus, Provider, ProviderJob
+
+_TIMEOUT = httpx.Timeout(120.0, connect=10.0)
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {get_settings().openai_api_key}"}
+
+
+class OpenAITranscribe(Provider):
+    """args: {audio: bytes, mime_type: str} -> {text, language}"""
+
+    name = "transcribe"
+
+    def submit(self, args: dict) -> ProviderJob:
+        settings = get_settings()
+        suffix = "mp4" if "mp4" in args["mime_type"] else "webm"
+        response = httpx.post(
+            f"{settings.openai_base_url}/audio/transcriptions",
+            headers=_headers(),
+            files={"file": (f"entry.{suffix}", args["audio"], args["mime_type"])},
+            data={"model": settings.transcribe_model, "response_format": "json"},
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        minutes = float(args.get("duration_ms", 120_000)) / 60_000
+        return ProviderJob(
+            id=uuid4().hex,
+            status=JobStatus.DONE,
+            output={"text": payload["text"], "language": payload.get("language", "")},
+            cost_estimate_usd=round(0.003 * minutes, 6),
+        )
+
+    def check(self, job_id: str) -> ProviderJob:
+        raise NotImplementedError("Transcription completes synchronously")
+
+
+class OpenAIChat(Provider):
+    """args: {prompt: str, purpose: str, temperature?: float} -> {text}"""
+
+    name = "llm"
+
+    def submit(self, args: dict) -> ProviderJob:
+        settings = get_settings()
+        response = httpx.post(
+            f"{settings.openai_base_url}/chat/completions",
+            headers=_headers(),
+            json={
+                "model": settings.llm_model,
+                "messages": [{"role": "user", "content": args["prompt"]}],
+                "temperature": args.get("temperature", 0.7),
+                "response_format": {"type": "json_object"},
+            },
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        usage = payload.get("usage", {})
+        # Rough blended estimate; exact rates tracked in the cost dashboard later.
+        in_tok = usage.get("prompt_tokens", 0)
+        out_tok = usage.get("completion_tokens", 0)
+        cost = (in_tok * 0.15 + out_tok * 0.6) / 1e6
+        return ProviderJob(
+            id=payload.get("id", uuid4().hex),
+            status=JobStatus.DONE,
+            output={"text": payload["choices"][0]["message"]["content"]},
+            cost_estimate_usd=round(cost, 6),
+        )
+
+    def check(self, job_id: str) -> ProviderJob:
+        raise NotImplementedError("Chat completes synchronously")

--- a/api/app/providers/registry.py
+++ b/api/app/providers/registry.py
@@ -1,38 +1,74 @@
 """Provider lookup honoring the fake_providers setting."""
 
+import json
+
 from app.core.config import get_settings
 from app.providers.base import FakeProvider, Provider
 
-_fakes: dict[str, Provider] = {}
+_instances: dict[str, Provider] = {}
+
+_FAKE_STORY = {
+    "title": "The Rice She Always Burned",
+    "story": (
+        "Every Sunday the kitchen filled with the same smell — rice, caught a "
+        "minute too long at the bottom of the pot.\n\nI used to think it was "
+        "carelessness. Now I think it was because she never once sat down "
+        "while we ate."
+    ),
+    "language": "en",
+    "signature": {"tone": "bittersweet", "themes": ["family", "memory"], "people": ["ema"]},
+}
 
 
-def _fake(name: str, output_fn, cost: float) -> Provider:
-    if name not in _fakes:
-        _fakes[name] = FakeProvider(name, output_fn, cost)
-    return _fakes[name]
+def _fake_llm_output(args: dict) -> dict:
+    if args.get("purpose") == "crisis":
+        return {"text": json.dumps({"flag": False, "reason": ""})}
+    return {"text": json.dumps(_FAKE_STORY)}
 
 
-def get_provider(name: str) -> Provider:
+def _build_fake(name: str) -> Provider:
+    if name == "transcribe":
+        return FakeProvider(
+            "transcribe",
+            lambda a: {
+                "text": (
+                    "Every Sunday my mother cooked rice and she always burned it a "
+                    "little. I used to find it annoying and now I miss that smell."
+                ),
+                "language": "en",
+            },
+            cost=0.006,
+        )
+    if name == "llm":
+        return FakeProvider("llm", _fake_llm_output, cost=0.02)
+    if name == "music":
+        return FakeProvider("music", lambda a: {"audio_url": "fake://song.mp3"}, cost=0.045)
+    if name == "video":
+        return FakeProvider("video", lambda a: {"video_url": "fake://film.mp4"}, cost=1.50)
+    if name == "tts":
+        return FakeProvider("tts", lambda a: {"audio_url": "fake://voice.mp3"}, cost=0.05)
+    raise KeyError(name)
+
+
+def _build_real(name: str) -> Provider:
     settings = get_settings()
-    if settings.fake_providers:
-        return {
-            "transcribe": lambda: _fake(
-                "transcribe", lambda a: {"text": "(fake transcript)", "language": "et"}, 0.006
-            ),
-            "llm": lambda: _fake(
-                "llm", lambda a: {"text": "(fake completion)"}, 0.02
-            ),
-            "music": lambda: _fake(
-                "music", lambda a: {"audio_url": "fake://song.mp3"}, 0.045
-            ),
-            "video": lambda: _fake(
-                "video", lambda a: {"video_url": "fake://film.mp4"}, 1.50
-            ),
-            "tts": lambda: _fake(
-                "tts", lambda a: {"audio_url": "fake://voice.mp3"}, 0.05
-            ),
-        }[name]()
+    if name in ("transcribe", "llm"):
+        if not settings.openai_api_key:
+            raise RuntimeError(
+                f"Provider '{name}' needs OPENAI_API_KEY; set it or enable FAKE_PROVIDERS."
+            )
+        from app.providers.openai import OpenAIChat, OpenAITranscribe
+
+        return OpenAITranscribe() if name == "transcribe" else OpenAIChat()
     raise NotImplementedError(
         f"Real provider '{name}' lands with its pipeline phase (see docs/plan/05); "
         "set FAKE_PROVIDERS=true until then."
     )
+
+
+def get_provider(name: str) -> Provider:
+    mode = "fake" if get_settings().fake_providers else "real"
+    key = f"{mode}:{name}"
+    if key not in _instances:
+        _instances[key] = _build_fake(name) if mode == "fake" else _build_real(name)
+    return _instances[key]

--- a/api/app/routes/entries.py
+++ b/api/app/routes/entries.py
@@ -1,0 +1,98 @@
+"""Entries: the capture side of the core loop."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+from app.clients.media import get_media_store
+from app.core.auth import AuthedUser, CurrentUser
+from app.core.config import get_settings
+from app.pipelines.distill import new_distill_run
+from app.routes.deps import get_runner
+from app.stores import collections
+
+router = APIRouter(tags=["entries"])
+
+ALLOWED_MIME = {"audio/webm", "audio/mp4", "audio/mpeg", "audio/ogg"}
+MAX_AUDIO_BYTES = 25 * 1024 * 1024  # ~25MB covers >10 min of opus comfortably
+
+
+def _check_daily_budget(user_id: str) -> None:
+    today = datetime.now(UTC).date().isoformat()
+    recent = collections.entries().list_by_user(user_id, limit=get_settings().daily_entry_limit)
+    todays = [e for e in recent if str(e.get("created_at", "")).startswith(today)]
+    if len(todays) >= get_settings().daily_entry_limit:
+        raise HTTPException(
+            status_code=429,
+            detail="The studio closes for the night after this many stories — see you tomorrow.",
+        )
+
+
+def _create_entry(user: AuthedUser, **fields) -> dict:
+    entry = {
+        "id": uuid4().hex,
+        "user_id": user.uid,
+        "status": "distilling",
+        "story_id": None,
+        "created_at": datetime.now(UTC).isoformat(),
+        **fields,
+    }
+    collections.entries().set(entry["id"], entry)
+    run = get_runner().start(new_distill_run(user.uid, entry["id"]))
+    entry["run_id"] = run.id
+    collections.entries().set(entry["id"], entry)
+    return entry
+
+
+@router.post("/entries/audio")
+async def create_audio_entry(
+    file: UploadFile = File(...),
+    duration_ms: int = Form(0),
+    user: AuthedUser = CurrentUser,
+) -> dict:
+    _check_daily_budget(user.uid)
+    mime = (file.content_type or "").split(";")[0].strip()
+    if mime not in ALLOWED_MIME:
+        raise HTTPException(status_code=415, detail=f"Unsupported audio type: {mime}")
+    data = await file.read()
+    if len(data) > MAX_AUDIO_BYTES:
+        raise HTTPException(status_code=413, detail="Recording too large")
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty recording")
+
+    suffix = ".mp4" if "mp4" in mime else ".webm"
+    ref = get_media_store().save(data, suffix)
+    entry = _create_entry(
+        user, source="voice", audio_ref=ref, mime_type=mime, duration_ms=duration_ms
+    )
+    return {"entry_id": entry["id"], "status": entry["status"]}
+
+
+class TextEntry(BaseModel):
+    text: str = Field(min_length=20, max_length=20_000)
+
+
+@router.post("/entries/text")
+def create_text_entry(body: TextEntry, user: AuthedUser = CurrentUser) -> dict:
+    _check_daily_budget(user.uid)
+    entry = _create_entry(user, source="text", transcript=body.text)
+    return {"entry_id": entry["id"], "status": entry["status"]}
+
+
+@router.get("/entries/{entry_id}")
+def get_entry(entry_id: str, user: AuthedUser = CurrentUser) -> dict:
+    entry = collections.entries().get(entry_id)
+    if entry is None or entry["user_id"] != user.uid:
+        raise HTTPException(status_code=404, detail="Entry not found")
+
+    run = get_runner().store.get(entry.get("run_id", ""))
+    status = entry["status"]
+    if run is not None and run.status == "failed" and status != "done":
+        status = "failed"
+
+    story = None
+    if entry.get("story_id"):
+        story = collections.stories().get(entry["story_id"])
+    return {"entry_id": entry_id, "status": status, "story": story}

--- a/api/app/routes/stories.py
+++ b/api/app/routes/stories.py
@@ -1,0 +1,40 @@
+"""Stories: the Chronicle's read surface + the daily question."""
+
+import json
+import random
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from app.core.auth import AuthedUser, CurrentUser
+from app.stores import collections
+
+router = APIRouter(tags=["stories"])
+
+_QUESTIONS = json.loads(
+    (Path(__file__).parent.parent / "assets" / "daily_questions.json").read_text(encoding="utf-8")
+)["universal"]
+
+
+@router.get("/stories")
+def list_stories(user: AuthedUser = CurrentUser) -> dict:
+    stories = collections.stories().list_by_user(user.uid)
+    return {"stories": stories}
+
+
+@router.get("/stories/{story_id}")
+def get_story(story_id: str, user: AuthedUser = CurrentUser) -> dict:
+    story = collections.stories().get(story_id)
+    if story is None or story["user_id"] != user.uid:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return story
+
+
+@router.get("/daily-question")
+def daily_question(user: AuthedUser = CurrentUser) -> dict:
+    """Deterministic per user per day; context-aware selection lands in P1.4+."""
+    day = datetime.now(UTC).date().toordinal()
+    rng = random.Random(f"{user.uid}:{day}")
+    question = rng.choice(_QUESTIONS)
+    return {"id": question["id"], "en": question["en"], "et": question["et"]}

--- a/api/app/stores/collections.py
+++ b/api/app/stores/collections.py
@@ -1,0 +1,25 @@
+"""Named doc-store accessors (entries, stories) honoring the environment."""
+
+from functools import lru_cache
+
+from app.core.config import get_settings
+from app.stores.docs import DocStore, FirestoreDocStore, MemoryDocStore
+
+
+@lru_cache
+def _store(collection: str) -> DocStore:
+    if get_settings().environment == "test":
+        return MemoryDocStore()
+    return FirestoreDocStore(collection)
+
+
+def entries() -> DocStore:
+    return _store("v2_entries")
+
+
+def stories() -> DocStore:
+    return _store("v2_stories")
+
+
+def reset_for_tests() -> None:
+    _store.cache_clear()

--- a/api/app/stores/docs.py
+++ b/api/app/stores/docs.py
@@ -1,0 +1,47 @@
+"""Generic document persistence for entries/stories: Firestore or memory."""
+
+from typing import Any, Protocol, cast
+
+
+class DocStore(Protocol):
+    def set(self, doc_id: str, data: dict[str, Any]) -> None: ...
+    def get(self, doc_id: str) -> dict[str, Any] | None: ...
+    def list_by_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]: ...
+
+
+class FirestoreDocStore:
+    def __init__(self, collection: str) -> None:
+        from google.cloud import firestore
+
+        self._col = firestore.Client().collection(collection)
+
+    def set(self, doc_id: str, data: dict[str, Any]) -> None:
+        self._col.document(doc_id).set(data)
+
+    def get(self, doc_id: str) -> dict[str, Any] | None:
+        snap = cast(Any, self._col.document(doc_id).get())
+        return cast(dict[str, Any], snap.to_dict()) if snap.exists else None
+
+    def list_by_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        query = (
+            self._col.where("user_id", "==", user_id)
+            .order_by("created_at", direction="DESCENDING")
+            .limit(limit)
+        )
+        return [cast(dict[str, Any], d.to_dict()) for d in query.stream()]
+
+
+class MemoryDocStore:
+    def __init__(self) -> None:
+        self._docs: dict[str, dict[str, Any]] = {}
+
+    def set(self, doc_id: str, data: dict[str, Any]) -> None:
+        self._docs[doc_id] = data
+
+    def get(self, doc_id: str) -> dict[str, Any] | None:
+        return self._docs.get(doc_id)
+
+    def list_by_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        mine = [d for d in self._docs.values() if d.get("user_id") == user_id]
+        mine.sort(key=lambda d: d.get("created_at", ""), reverse=True)
+        return mine[:limit]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -9,6 +9,8 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
+# FastAPI's dependency-injection idiom requires calls in argument defaults.
+ignore = ["B008"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,3 +7,4 @@ google-cloud-tasks==2.19.2
 sentry-sdk[fastapi]==2.29.1
 httpx==0.28.1
 python-dotenv==1.1.0
+python-multipart==0.0.20

--- a/api/scripts/real_loop_check.py
+++ b/api/scripts/real_loop_check.py
@@ -1,0 +1,56 @@
+"""Manual end-to-end check of the core loop against REAL providers.
+
+Usage: python3 scripts/real_loop_check.py  (reads OPENAI_API_KEY from api/.env)
+Costs a few cents. Not part of the test suite.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.core.auth import AuthedUser, get_current_user  # noqa: E402
+from app.main import app  # noqa: E402
+
+SAMPLE_ET = (
+    "Ma käisin eile õhtul vanaema juures. Ta elab ikka veel selles samas "
+    "korteris Mustamäel, kus ma lapsena suvesid veetsin. Ta tegi pannkooke "
+    "ja ütles, et ma olen liiga kõhnaks jäänud, nagu alati. Köögis lõhnas "
+    "täpselt samamoodi nagu kakskümmend aastat tagasi. Mingi hetk ta hakkas "
+    "rääkima vanaisast, kuidas nad nooruses Pärnu rannas käisid, ja ta "
+    "naeris nii, et pisarad tulid silma. Ma ei osanud midagi öelda, "
+    "istusin lihtsalt ja kuulasin. Koju sõites mõtlesin, et peaksin "
+    "tihedamini käima. Iga kord ma mõtlen seda."
+)
+
+
+def main() -> None:
+    app.dependency_overrides[get_current_user] = lambda: AuthedUser(
+        uid="founder-real-test", email="founder@test", name="Founder"
+    )
+    client = TestClient(app)
+
+    print("Posting Estonian text entry against REAL providers...")
+    res = client.post("/api/entries/text", json={"text": SAMPLE_ET})
+    res.raise_for_status()
+    entry_id = res.json()["entry_id"]
+
+    result = client.get(f"/api/entries/{entry_id}").json()
+    print(f"\nStatus: {result['status']}")
+    story = result.get("story")
+    if not story:
+        print("No story produced — check pipeline logs above.")
+        sys.exit(1)
+
+    print(f"\n=== {story['title']} ===")
+    print(story["story"])
+    print(f"\nLanguage: {story['language']}")
+    print(f"Signature: {story['signature']}")
+    print(f"Recommendation: {story['recommendation']}")
+    print(f"Support flag: {story['support_flag']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -9,9 +9,14 @@ TEST_USER = AuthedUser(uid="test-uid", email="test@example.com", name="Test User
 
 
 @pytest.fixture
-def client():
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOAD_DIR", str(tmp_path / "uploads"))
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
     deps.get_runner.cache_clear()  # fresh in-memory store per test
     app.dependency_overrides[get_current_user] = lambda: TEST_USER
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+    get_settings.cache_clear()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -11,6 +11,9 @@ TEST_USER = AuthedUser(uid="test-uid", email="test@example.com", name="Test User
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("UPLOAD_DIR", str(tmp_path / "uploads"))
+    # Tests must never hit real providers or spend money, regardless of local .env.
+    monkeypatch.setenv("FAKE_PROVIDERS", "true")
+    monkeypatch.setenv("ENVIRONMENT", "test")
     from app.core.config import get_settings
 
     get_settings.cache_clear()

--- a/api/tests/test_core_loop.py
+++ b/api/tests/test_core_loop.py
@@ -27,7 +27,7 @@ def test_text_entry_distills_into_story(client):
     assert story["signature"]["tone"] == "bittersweet"
     assert story["recommendation"]["format"] == "song"
     assert story["support_flag"] is False
-    assert story["prompt_ref"] == "distill@v1"
+    assert story["prompt_ref"] == "distill@v2"
 
 
 def test_audio_entry_distills_into_story(client, tmp_path, monkeypatch):
@@ -84,9 +84,22 @@ def test_daily_question_is_stable_within_a_day(client):
 def test_distill_prompt_renders_transcript_verbatim():
     from app.prompts.loader import load_prompt
 
-    prompt = load_prompt("distill@v1")
+    prompt = load_prompt("distill@v2")
     rendered = prompt.render(transcript="she always burned the rice")
     assert "she always burned the rice" in rendered
     assert "{transcript}" not in rendered
-    assert "Never invent biographical facts" in rendered
+    # The clauses the product depends on must survive prompt edits.
+    assert "Never invent" in rendered
+    assert "No closing moral" in rendered
+    assert "IN THE STORY'S LANGUAGE" in rendered
     assert prompt.meta["name"] == "distill"
+    assert prompt.meta["version"] == "2"
+
+
+def test_recommendation_reasons_are_bilingual(client):
+    client.post(
+        "/api/entries/text",
+        json={"text": "A long enough text about a small quiet morning at home."},
+    )
+    story = client.get("/api/stories").json()["stories"][0]
+    assert {"en", "et"} <= story["recommendation"]["reason"].keys()

--- a/api/tests/test_core_loop.py
+++ b/api/tests/test_core_loop.py
@@ -1,0 +1,92 @@
+import io
+
+import pytest
+
+from app.stores import collections
+
+
+@pytest.fixture(autouse=True)
+def fresh_stores():
+    collections.reset_for_tests()
+    yield
+    collections.reset_for_tests()
+
+
+def test_text_entry_distills_into_story(client):
+    res = client.post(
+        "/api/entries/text",
+        json={"text": "Every Sunday my mother cooked rice and she always burned it a little."},
+    )
+    assert res.status_code == 200
+    entry_id = res.json()["entry_id"]
+
+    result = client.get(f"/api/entries/{entry_id}").json()
+    assert result["status"] == "done"
+    story = result["story"]
+    assert story["title"] == "The Rice She Always Burned"
+    assert story["signature"]["tone"] == "bittersweet"
+    assert story["recommendation"]["format"] == "song"
+    assert story["support_flag"] is False
+    assert story["prompt_ref"] == "distill@v1"
+
+
+def test_audio_entry_distills_into_story(client, tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOAD_DIR", str(tmp_path))
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+
+    fake_audio = io.BytesIO(b"\x1aE\xdf\xa3 not really webm but enough for the fake provider")
+    res = client.post(
+        "/api/entries/audio",
+        files={"file": ("entry.webm", fake_audio, "audio/webm")},
+        data={"duration_ms": "94000"},
+    )
+    assert res.status_code == 200, res.text
+    entry_id = res.json()["entry_id"]
+
+    result = client.get(f"/api/entries/{entry_id}").json()
+    assert result["status"] == "done"
+    assert result["story"]["title"] == "The Rice She Always Burned"
+
+    get_settings.cache_clear()
+
+
+def test_audio_entry_rejects_unknown_mime(client):
+    res = client.post(
+        "/api/entries/audio",
+        files={"file": ("entry.exe", io.BytesIO(b"xx"), "application/octet-stream")},
+    )
+    assert res.status_code == 415
+
+
+def test_story_listing_and_isolation(client):
+    client.post("/api/entries/text", json={"text": "A long enough text about my quiet morning."})
+    stories = client.get("/api/stories").json()["stories"]
+    assert len(stories) == 1
+
+    story_id = stories[0]["id"]
+    from app.core.auth import AuthedUser, get_current_user
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: AuthedUser(uid="intruder")
+    assert client.get(f"/api/stories/{story_id}").status_code == 404
+    assert client.get("/api/stories").json()["stories"] == []
+
+
+def test_daily_question_is_stable_within_a_day(client):
+    first = client.get("/api/daily-question").json()
+    second = client.get("/api/daily-question").json()
+    assert first == second
+    assert {"id", "en", "et"} <= first.keys()
+
+
+def test_distill_prompt_renders_transcript_verbatim():
+    from app.prompts.loader import load_prompt
+
+    prompt = load_prompt("distill@v1")
+    rendered = prompt.render(transcript="she always burned the rice")
+    assert "she always burned the rice" in rendered
+    assert "{transcript}" not in rendered
+    assert "Never invent biographical facts" in rendered
+    assert prompt.meta["name"] == "distill"

--- a/deploy/.firebaserc
+++ b/deploy/.firebaserc
@@ -1,0 +1,12 @@
+{
+  "projects": {
+    "default": "sentimental-f95e6"
+  },
+  "targets": {
+    "sentimental-f95e6": {
+      "hosting": {
+        "sentimentalapp-test": ["sentimentalapp-test"]
+      }
+    }
+  }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,22 @@
+# Deployment config (Sentimental v2)
+
+v2 deploys to its own surfaces so the legacy app stays untouched until the
+traffic flip (see `LEGACY.md` and `docs/plan/03`):
+
+| Surface | Where | Config |
+|---|---|---|
+| API | Cloud Run service `sentimental-api-v2` (europe-west1) | `.github/workflows/deploy.yml` |
+| Web | Firebase Hosting site `sentimentalapp-test` | this folder |
+
+Root `firebase.json` / `.firebaserc` remain the **legacy** hosting config.
+
+## Required GitHub Actions secrets
+
+| Secret | Purpose |
+|---|---|
+| `GCP_SA_KEY` | service account JSON: Cloud Run deploy + build |
+| `FIREBASE_SA_KEY` | service account JSON: Firebase Hosting deploy |
+| `OPENAI_API_KEY` | passed to Cloud Run; enables real providers |
+
+Without the first two, the deploy workflow skips quietly. Without the third,
+the API starts with `FAKE_PROVIDERS=true` (deterministic outputs, zero spend).

--- a/deploy/firebase.json
+++ b/deploy/firebase.json
@@ -1,0 +1,32 @@
+{
+  "hosting": {
+    "target": "sentimentalapp-test",
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*"],
+    "rewrites": [
+      {
+        "source": "/api/**",
+        "run": {
+          "serviceId": "sentimental-api-v2",
+          "region": "europe-west1"
+        }
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "/assets/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        ]
+      },
+      {
+        "source": "/sw.js",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      }
+    ]
+  }
+}

--- a/docs/plan/01-core-loop-and-product.md
+++ b/docs/plan/01-core-loop-and-product.md
@@ -74,6 +74,29 @@ is still unmistakably *them*, just smoother (or deliberately cooler).
 - **Status:** parked in the Phase 5 experiment backlog with a metric hypothesis;
   not part of the launch loop.
 
+### Parked capture mode: "The Listener" (waiting on GPT-Live API)
+
+OpenAI's GPT-Live (announced 2026-07-08) is a full-duplex voice model: it
+listens and speaks simultaneously, backchannels naturally ("mhmm"), stays
+quiet while the speaker thinks, and delegates deeper reasoning to a frontier
+model in the background. ChatGPT-only at launch; **API "coming soon"** — we
+signed up for the waitlist and build nothing on it until it ships.
+
+When the API opens, the Booth gains an optional guided mode: a gentle
+interviewer that asks the right follow-up at the right moment, by voice.
+The conversation transcript feeds the existing distill pipeline unchanged —
+this is a new capture surface, not a new architecture.
+
+Boundaries (non-negotiable, aligned with our ethical guardrails):
+- The Listener is an *interviewer*, never a companion. It asks, listens, and
+  hands back a story; it does not build a relationship. This is both an
+  emotional-reliance safeguard (OpenAI flags this risk themselves) and our
+  positioning: the AI is the studio, not a friend.
+- Estonian fluency must be verified before launch in ET (OpenAI acknowledges
+  non-native accents / fluency gaps in smaller languages at launch).
+- Session cost will exceed the one-shot voice note; guided mode enters the
+  credit system, the plain voice note stays free.
+
 ## The weekly payoff: "Your Episode"
 
 Every week, for users with ≥2 entries, the app auto-generates a **weekly episode**:

--- a/docs/plan/05-execution-roadmap.md
+++ b/docs/plan/05-execution-roadmap.md
@@ -99,7 +99,10 @@ voice-cloned narration (consent flow), yearly Wrapped film, paid tier activation
 embeddings-based context retrieval, occasion reminders, **Polished Note**
 (voice-message polishing in the user's real voice via timestamp-cut editing —
 concept in 01; hypothesis: a DM-native artifact with person-to-person
-distribution lifts new-user acquisition without touching the core loop).
+distribution lifts new-user acquisition without touching the core loop),
+**The Listener** (guided voice capture on GPT-Live once its API ships —
+concept and boundaries in 01; hypothesis: guided entries run longer and
+yield higher keep-rate stories than one-shot voice notes).
 Each item enters a phase only with a metric hypothesis attached.
 
 ## Cross-cutting tracks (run through all phases)

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -1,6 +1,9 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import { useAuth } from "../features/auth/AuthProvider";
 import { SignIn } from "../features/auth/SignIn";
+import { SpeakScreen } from "../features/speak/SpeakScreen";
+import { RevealScreen } from "../features/reveal/RevealScreen";
+import { StoryScreen } from "../features/stories/StoryScreen";
 import { Shell } from "./Shell";
 import { Tonight } from "./tabs/Tonight";
 import { Chronicle } from "./tabs/Chronicle";
@@ -23,6 +26,11 @@ export function App() {
 
   return (
     <Routes>
+      {/* Full-screen surfaces (no tab bar): the Booth, the Darkroom, the page */}
+      <Route path="/speak" element={<SpeakScreen />} />
+      <Route path="/entry/:entryId" element={<RevealScreen />} />
+      <Route path="/story/:storyId" element={<StoryScreen />} />
+
       <Route element={<Shell />}>
         <Route path="/" element={<Tonight />} />
         <Route path="/chronicle" element={<Chronicle />} />

--- a/web/src/app/tabs/Chronicle.tsx
+++ b/web/src/app/tabs/Chronicle.tsx
@@ -1,23 +1,97 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api, type Story } from "../../lib/api";
+import { toneStyle } from "../../lib/signature";
+
+function monthLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
 export function Chronicle() {
+  const [stories, setStories] = useState<Story[] | null>(null);
+
+  useEffect(() => {
+    api
+      .stories()
+      .then((r) => setStories(r.stories))
+      .catch(() => setStories([]));
+  }, []);
+
+  if (stories === null) {
+    return (
+      <section className="flex min-h-[50dvh] items-center justify-center">
+        <div className="breathe h-2 w-2 rounded-full bg-lamplight-500" aria-label="Loading" />
+      </section>
+    );
+  }
+
+  if (stories.length === 0) {
+    return (
+      <section className="develop-in px-6 pt-20">
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">Chronicle</p>
+        <h1 className="mt-6 font-prose text-3xl font-light text-ink-100">
+          Your shelves are waiting.
+        </h1>
+        <p className="mt-4 max-w-xs leading-relaxed text-ink-300">
+          Every story you tell is kept here — yours alone, until you choose otherwise.
+        </p>
+        <Link
+          to="/speak"
+          className="mt-10 inline-block rounded-full bg-lamplight-500 px-7 py-3 font-ui text-sm font-medium text-night-900"
+        >
+          Tell the first one
+        </Link>
+      </section>
+    );
+  }
+
+  const groups = new Map<string, Story[]>();
+  for (const story of stories) {
+    const key = monthLabel(story.created_at);
+    groups.set(key, [...(groups.get(key) ?? []), story]);
+  }
+
   return (
     <section className="develop-in px-6 pt-20">
-      <p className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">
-        Chronicle
-      </p>
-      <h1 className="mt-6 font-prose text-3xl font-light text-ink-100">
-        Your shelves are waiting.
-      </h1>
-      <p className="mt-4 max-w-xs leading-relaxed text-ink-300">
-        Every story you tell is kept here — yours alone, until you choose
-        otherwise.
-      </p>
+      <p className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">Chronicle</p>
 
-      <div className="mt-12 space-y-3" aria-hidden>
-        {/* Placeholder shelf: the empty state hints at what will live here */}
-        <div className="h-16 rounded-xl border border-night-600 border-l-2 border-l-sig-joy bg-night-800 opacity-50" />
-        <div className="h-16 rounded-xl border border-night-600 border-l-2 border-l-sig-calm bg-night-800 opacity-50" />
-        <div className="h-16 rounded-xl border border-night-600 border-l-2 border-l-sig-bittersweet bg-night-800 opacity-50" />
-      </div>
+      {[...groups.entries()].map(([month, monthStories]) => (
+        <div key={month} className="mt-8">
+          <div className="flex items-center gap-3">
+            <h2 className="text-sm font-medium text-ink-300">{month}</h2>
+            {/* The month's color strip: the chronicle readable at a glance */}
+            <div className="flex gap-1" aria-hidden>
+              {monthStories.slice(0, 12).map((s) => (
+                <span
+                  key={s.id}
+                  className={`h-2 w-2 rounded-full ${toneStyle(s.signature.tone).text}`}
+                  style={{ backgroundColor: "currentcolor" }}
+                />
+              ))}
+            </div>
+          </div>
+
+          <ul className="mt-3 space-y-3">
+            {monthStories.map((story) => {
+              const tone = toneStyle(story.signature.tone);
+              return (
+                <li key={story.id}>
+                  <Link
+                    to={`/story/${story.id}`}
+                    className={`block rounded-xl border border-night-600 border-l-2 ${tone.border} bg-night-800 p-4 transition-colors duration-150 hover:border-night-500`}
+                  >
+                    <h3 className="font-prose text-lg font-light text-ink-100">{story.title}</h3>
+                    <p className="mt-1 text-xs text-ink-500">
+                      <span className={tone.text}>{tone.label}</span>
+                      {story.signature.themes.length > 0 && <> · {story.signature.themes.join(", ")}</>}
+                    </p>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
     </section>
   );
 }

--- a/web/src/app/tabs/Tonight.tsx
+++ b/web/src/app/tabs/Tonight.tsx
@@ -1,32 +1,54 @@
-/**
- * Tonight — the home of the core loop: today's question + the record button.
- * Phase 0 ships the composed surface; recording wires up in Phase 1 (P1.1).
- */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api, type DailyQuestion, type Story } from "../../lib/api";
+
+function pickLanguage(q: DailyQuestion): string {
+  return navigator.language?.toLowerCase().startsWith("et") ? q.et : q.en;
+}
+
 export function Tonight() {
+  const [question, setQuestion] = useState<DailyQuestion | null>(null);
+  const [latest, setLatest] = useState<Story | null>(null);
+
+  useEffect(() => {
+    api.dailyQuestion().then(setQuestion).catch(() => null);
+    api
+      .stories()
+      .then((r) => setLatest(r.stories[0] ?? null))
+      .catch(() => null);
+  }, []);
+
   return (
     <section className="develop-in flex min-h-[calc(100dvh-6rem)] flex-col justify-between px-6 pt-20">
       <header>
-        <p className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">
-          Tonight
-        </p>
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-ink-500">Tonight</p>
         <h1 className="mt-6 font-prose text-[2rem] font-light leading-snug text-ink-100">
-          Tell me about a moment from this year you keep coming back to.
+          {question ? pickLanguage(question) : "\u00a0"}
         </h1>
       </header>
 
-      <div className="flex flex-col items-center gap-4 pb-10">
-        <button
-          aria-label="Start speaking (available soon)"
-          disabled
-          className="breathe flex h-20 w-20 items-center justify-center rounded-full bg-lamplight-500 text-night-900 shadow-[0_0_40px_-8px] shadow-lamplight-500/60 disabled:opacity-80"
+      <div className="flex flex-col items-center gap-6 pb-8">
+        <Link
+          to="/speak"
+          aria-label="Start speaking"
+          className="breathe flex h-20 w-20 items-center justify-center rounded-full bg-lamplight-500 text-night-900 shadow-[0_0_40px_-8px] shadow-lamplight-500/60 transition-transform duration-150 active:scale-95"
         >
           <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
             <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
             <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
             <line x1="12" y1="19" x2="12" y2="22" />
           </svg>
-        </button>
-        <p className="text-sm text-ink-500">The booth opens soon.</p>
+        </Link>
+
+        {latest && (
+          <Link
+            to={`/story/${latest.id}`}
+            className="w-full rounded-xl border border-night-600 bg-night-800/70 p-4 text-left"
+          >
+            <p className="text-xs text-ink-500">Last from the shelf</p>
+            <p className="mt-1 font-prose text-base text-ink-300">{latest.title}</p>
+          </Link>
+        )}
       </div>
     </section>
   );

--- a/web/src/features/reveal/RevealScreen.tsx
+++ b/web/src/features/reveal/RevealScreen.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { api, type EntryStatus } from "../../lib/api";
+import { capabilities } from "../../capabilities";
+import { StoryCard } from "../stories/StoryCard";
+
+const POLL_MS = 1500;
+
+export function RevealScreen() {
+  const { entryId } = useParams<{ entryId: string }>();
+  const navigate = useNavigate();
+  const [entry, setEntry] = useState<EntryStatus | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!entryId) return;
+    let cancelled = false;
+    let timer: number;
+
+    const poll = async () => {
+      try {
+        const next = await api.entry(entryId);
+        if (cancelled) return;
+        setEntry(next);
+        if (next.status === "distilling") {
+          timer = window.setTimeout(() => void poll(), POLL_MS);
+        } else if (next.status === "done") {
+          capabilities.haptics.tap();
+        } else {
+          setFailed(true);
+        }
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [entryId]);
+
+  if (failed) {
+    return (
+      <main className="flex min-h-dvh flex-col items-center justify-center gap-6 px-8 text-center">
+        <p className="font-prose text-xl font-light text-ink-100">
+          The darkroom hiccuped — your words are safe, but the story didn't
+          develop this time.
+        </p>
+        <button
+          onClick={() => navigate("/", { replace: true })}
+          className="rounded-full border border-night-500 px-6 py-2.5 text-sm text-ink-300"
+        >
+          Back to tonight
+        </button>
+      </main>
+    );
+  }
+
+  if (!entry || entry.status === "distilling" || !entry.story) {
+    return (
+      <main className="flex min-h-dvh flex-col items-center justify-center gap-8 px-8 text-center">
+        <div className="breathe h-16 w-16 rounded-full bg-dusk-500/25 shadow-[0_0_60px_-10px] shadow-dusk-500/60" aria-hidden />
+        <p className="font-prose text-xl font-light text-dusk-300" aria-live="polite">
+          Developing your story…
+        </p>
+      </main>
+    );
+  }
+
+  const story = entry.story;
+  return (
+    <main className="mx-auto min-h-dvh max-w-md px-5 pb-12 pt-10">
+      <StoryCard story={story} animate />
+
+      <div className="develop-in mt-6 space-y-4" style={{ animationDelay: "400ms" }}>
+        <div className="rounded-xl border border-dusk-600/40 bg-dusk-600/10 p-4">
+          <p className="text-sm leading-relaxed text-dusk-300">
+            <span className="font-medium">This wants to be a {story.recommendation.format}</span>
+            {" — "}
+            {story.recommendation.reason}. <span className="text-ink-500">(coming in the next phase)</span>
+          </p>
+        </div>
+
+        <div className="flex gap-3">
+          <Link
+            to="/chronicle"
+            className="flex-1 rounded-full bg-lamplight-500 py-3 text-center font-ui text-sm font-medium text-night-900"
+          >
+            Keep
+          </Link>
+          <button disabled className="flex-1 rounded-full border border-night-500 py-3 text-sm text-ink-500" title="Coming soon">
+            Share
+          </button>
+          <button disabled className="flex-1 rounded-full border border-night-500 py-3 text-sm text-ink-500" title="Coming soon">
+            Gift
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/features/reveal/RevealScreen.tsx
+++ b/web/src/features/reveal/RevealScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { api, type EntryStatus } from "../../lib/api";
 import { capabilities } from "../../capabilities";
+import { recommendationText } from "../../lib/i18n";
 import { StoryCard } from "../stories/StoryCard";
 
 const POLL_MS = 1500;
@@ -76,9 +77,8 @@ export function RevealScreen() {
       <div className="develop-in mt-6 space-y-4" style={{ animationDelay: "400ms" }}>
         <div className="rounded-xl border border-dusk-600/40 bg-dusk-600/10 p-4">
           <p className="text-sm leading-relaxed text-dusk-300">
-            <span className="font-medium">This wants to be a {story.recommendation.format}</span>
-            {" — "}
-            {story.recommendation.reason}. <span className="text-ink-500">(coming in the next phase)</span>
+            <span className="font-medium">{recommendationText(story)}</span>{" "}
+            <span className="text-ink-500">(coming in the next phase)</span>
           </p>
         </div>
 

--- a/web/src/features/speak/SpeakScreen.tsx
+++ b/web/src/features/speak/SpeakScreen.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { capabilities } from "../../capabilities";
+import { api } from "../../lib/api";
+import { Waveform } from "./Waveform";
+
+const SILENCE_LEVEL = 0.06;
+const NUDGE_AFTER_MS = 8_000;
+const MAX_DURATION_MS = 5 * 60_000;
+
+const MICRO_PROMPTS = [
+  "What happened next?",
+  "How did that feel?",
+  "Who else was there?",
+  "What do you remember most clearly?",
+];
+
+type Mode = "idle" | "recording" | "uploading" | "typing" | "error";
+
+export function SpeakScreen() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<Mode>("idle");
+  const [level, setLevel] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+  const [nudge, setNudge] = useState<string | null>(null);
+  const [text, setText] = useState("");
+  const [error, setError] = useState("");
+
+  const lastVoiceAt = useRef(Date.now());
+  const startedAt = useRef(0);
+  const nudgeIndex = useRef(0);
+
+  const onLevel = useCallback((v: number) => {
+    setLevel(v);
+    if (v > SILENCE_LEVEL) {
+      lastVoiceAt.current = Date.now();
+      setNudge(null);
+    }
+  }, []);
+
+  // Elapsed timer + silence nudges + max-duration stop.
+  useEffect(() => {
+    if (mode !== "recording") return;
+    const interval = window.setInterval(() => {
+      const now = Date.now();
+      setElapsed(now - startedAt.current);
+      if (now - lastVoiceAt.current > NUDGE_AFTER_MS) {
+        setNudge(MICRO_PROMPTS[nudgeIndex.current % MICRO_PROMPTS.length]);
+        nudgeIndex.current += 1;
+        lastVoiceAt.current = now; // don't repeat every tick
+      }
+      if (now - startedAt.current > MAX_DURATION_MS) void finish();
+    }, 500);
+    return () => window.clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
+
+  async function start() {
+    try {
+      await capabilities.mic.start(onLevel);
+      startedAt.current = Date.now();
+      lastVoiceAt.current = Date.now();
+      setElapsed(0);
+      setMode("recording");
+    } catch {
+      setMode("typing"); // mic denied/unavailable -> graceful text fallback
+    }
+  }
+
+  async function finish() {
+    setMode("uploading");
+    try {
+      const rec = await capabilities.mic.stop();
+      if (rec.durationMs < 3_000) {
+        setError("That was a very short one — try again?");
+        setMode("idle");
+        return;
+      }
+      const { entry_id } = await api.createAudioEntry(rec.blob, rec.durationMs);
+      capabilities.haptics.tap();
+      navigate(`/entry/${entry_id}`, { replace: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setMode("error");
+    }
+  }
+
+  async function submitText() {
+    setMode("uploading");
+    try {
+      const { entry_id } = await api.createTextEntry(text.trim());
+      navigate(`/entry/${entry_id}`, { replace: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setMode("error");
+    }
+  }
+
+  function cancel() {
+    if (mode === "recording") capabilities.mic.cancel();
+    navigate(-1);
+  }
+
+  const mins = Math.floor(elapsed / 60_000);
+  const secs = Math.floor((elapsed % 60_000) / 1000);
+
+  return (
+    <main className="flex min-h-dvh flex-col bg-night-900 px-6">
+      <header className="flex items-center justify-between pt-6">
+        <button onClick={cancel} className="p-2 text-ink-500 hover:text-ink-300" aria-label="Close">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden>
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+        {mode === "recording" && (
+          <span className="font-ui text-sm tabular-nums text-ink-300" aria-live="polite">
+            {mins}:{secs.toString().padStart(2, "0")}
+          </span>
+        )}
+      </header>
+
+      {mode === "typing" ? (
+        <section className="develop-in flex flex-1 flex-col pt-10">
+          <h1 className="font-prose text-2xl font-light text-ink-100">Write it instead.</h1>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            autoFocus
+            placeholder="Start anywhere. The middle is fine."
+            className="mt-6 flex-1 resize-none rounded-xl border border-night-600 bg-night-800 p-4 font-prose text-lg leading-relaxed text-ink-100 placeholder:text-ink-500 focus:border-dusk-500 focus:outline-none"
+          />
+          <button
+            onClick={() => void submitText()}
+            disabled={text.trim().length < 20}
+            className="mb-8 mt-4 rounded-full bg-lamplight-500 py-3.5 font-ui text-sm font-medium text-night-900 disabled:opacity-40"
+          >
+            Develop the story
+          </button>
+        </section>
+      ) : (
+        <section className="flex flex-1 flex-col items-center justify-between pb-12 pt-16 text-center">
+          <div className="develop-in" aria-live="polite">
+            {mode === "recording" ? (
+              <p className="font-prose text-xl font-light text-ink-300">
+                {nudge ?? "I'm listening."}
+              </p>
+            ) : mode === "uploading" ? (
+              <p className="font-prose text-xl font-light text-dusk-300">
+                Taking it to the darkroom…
+              </p>
+            ) : (
+              <p className="font-prose text-xl font-light text-ink-100">
+                Just talk. I'll do the rest.
+              </p>
+            )}
+            {error && <p className="mt-3 text-sm text-sig-bittersweet">{error}</p>}
+          </div>
+
+          {mode === "recording" && <Waveform level={level} />}
+
+          <div className="flex flex-col items-center gap-5">
+            {mode === "recording" ? (
+              <button
+                onClick={() => void finish()}
+                aria-label="Finish recording"
+                className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-lamplight-500 text-lamplight-400 shadow-[0_0_50px_-10px] shadow-lamplight-500/70"
+              >
+                <span className="block h-6 w-6 rounded bg-lamplight-500" />
+              </button>
+            ) : mode === "uploading" ? (
+              <div className="breathe h-20 w-20 rounded-full bg-dusk-500/30" aria-label="Uploading" />
+            ) : (
+              <button
+                onClick={() => void start()}
+                aria-label="Start recording"
+                className="breathe flex h-20 w-20 items-center justify-center rounded-full bg-lamplight-500 text-night-900 shadow-[0_0_50px_-10px] shadow-lamplight-500/70"
+              >
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+                  <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                  <line x1="12" y1="19" x2="12" y2="22" />
+                </svg>
+              </button>
+            )}
+            {mode === "idle" && (
+              <button onClick={() => setMode("typing")} className="text-sm text-ink-500 underline-offset-4 hover:text-ink-300 hover:underline">
+                write instead
+              </button>
+            )}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/web/src/features/speak/Waveform.tsx
+++ b/web/src/features/speak/Waveform.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * The amber thread (docs/plan/02): a level-meter that thickens and flares
+ * with the voice. Bars scroll left as time passes.
+ */
+export function Waveform({ level }: { level: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const barsRef = useRef<number[]>([]);
+  const levelRef = useRef(0);
+  levelRef.current = level;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * dpr;
+    canvas.height = canvas.clientHeight * dpr;
+    ctx.scale(dpr, dpr);
+
+    let raf = 0;
+    let lastSample = 0;
+    const draw = (now: number) => {
+      if (now - lastSample > 60) {
+        barsRef.current.push(levelRef.current);
+        const maxBars = Math.floor(canvas.clientWidth / 5);
+        if (barsRef.current.length > maxBars) barsRef.current.shift();
+        lastSample = now;
+      }
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      ctx.clearRect(0, 0, w, h);
+      barsRef.current.forEach((v, i) => {
+        const x = w - (barsRef.current.length - i) * 5;
+        const barH = Math.max(2, v * h * 0.9);
+        const glow = Math.min(1, 0.35 + v * 1.2);
+        ctx.fillStyle = `rgba(232, 168, 73, ${glow})`;
+        ctx.beginPath();
+        ctx.roundRect(x, (h - barH) / 2, 3, barH, 2);
+        ctx.fill();
+      });
+      raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return <canvas ref={canvasRef} className="h-24 w-full" aria-hidden />;
+}

--- a/web/src/features/stories/StoryCard.tsx
+++ b/web/src/features/stories/StoryCard.tsx
@@ -1,0 +1,44 @@
+import type { Story } from "../../lib/api";
+import { toneStyle } from "../../lib/signature";
+
+/** The artifact surface: editorial serif, Spectrum edge, film-grain feel. */
+export function StoryCard({ story, animate = false }: { story: Story; animate?: boolean }) {
+  const tone = toneStyle(story.signature.tone);
+
+  return (
+    <article
+      className={`rounded-2xl border border-night-600 border-l-2 ${tone.border} bg-night-800 p-6 ${
+        animate ? "develop-in" : ""
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className={`text-xs font-medium uppercase tracking-[0.15em] ${tone.text}`}>
+          {tone.label}
+        </span>
+        {story.signature.themes.length > 0 && (
+          <span className="text-xs text-ink-500">{story.signature.themes.join(" · ")}</span>
+        )}
+      </div>
+
+      <h2 className="mt-4 font-prose text-2xl font-light leading-snug text-ink-100">
+        {story.title}
+      </h2>
+
+      <div className="mt-5 space-y-4">
+        {story.story.split("\n\n").map((paragraph, i) => (
+          <p key={i} className="font-prose text-[17px] leading-relaxed text-ink-300">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+
+      {story.support_flag && (
+        <p className="mt-6 rounded-lg bg-night-700 p-4 text-sm leading-relaxed text-ink-300">
+          That sounded heavy. If you need someone to talk to, Eluliin is at{" "}
+          <a href="tel:6558088" className="text-lamplight-400">655 8088</a> (Estonia) — or reach
+          out to someone you trust.
+        </p>
+      )}
+    </article>
+  );
+}

--- a/web/src/features/stories/StoryScreen.tsx
+++ b/web/src/features/stories/StoryScreen.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { api, type Story } from "../../lib/api";
+import { StoryCard } from "./StoryCard";
+
+export function StoryScreen() {
+  const { storyId } = useParams<{ storyId: string }>();
+  const navigate = useNavigate();
+  const [story, setStory] = useState<Story | null>(null);
+  const [missing, setMissing] = useState(false);
+
+  useEffect(() => {
+    if (!storyId) return;
+    api
+      .story(storyId)
+      .then(setStory)
+      .catch(() => setMissing(true));
+  }, [storyId]);
+
+  return (
+    <main className="mx-auto min-h-dvh max-w-md px-5 pb-12 pt-6">
+      <button
+        onClick={() => navigate(-1)}
+        className="mb-4 p-2 text-ink-500 hover:text-ink-300"
+        aria-label="Back"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M19 12H5M12 19l-7-7 7-7" />
+        </svg>
+      </button>
+
+      {missing ? (
+        <p className="px-3 font-prose text-lg text-ink-300">This page is missing from the shelf.</p>
+      ) : story ? (
+        <StoryCard story={story} />
+      ) : (
+        <div className="flex min-h-[40dvh] items-center justify-center">
+          <div className="breathe h-2 w-2 rounded-full bg-lamplight-500" aria-label="Loading" />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,76 @@
+import { auth } from "../features/auth/firebase";
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+async function authHeader(): Promise<Record<string, string>> {
+  const user = auth.currentUser;
+  if (!user) throw new ApiError(401, "Not signed in");
+  return { Authorization: `Bearer ${await user.getIdToken()}` };
+}
+
+export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    ...init,
+    headers: { ...(init.headers ?? {}), ...(await authHeader()) },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new ApiError(res.status, body.detail ?? res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+export interface Signature {
+  tone: "joy" | "bittersweet" | "grief" | "pride" | "calm" | "longing" | "fear" | "wonder";
+  themes: string[];
+  people: string[];
+}
+
+export interface Story {
+  id: string;
+  title: string;
+  story: string;
+  language: string;
+  signature: Signature;
+  recommendation: { format: string; reason: { en: string; et: string } };
+  support_flag: boolean;
+  created_at: string;
+}
+
+export interface EntryStatus {
+  entry_id: string;
+  status: "distilling" | "done" | "failed";
+  story: Story | null;
+}
+
+export interface DailyQuestion {
+  id: string;
+  en: string;
+  et: string;
+}
+
+export const api = {
+  dailyQuestion: () => apiFetch<DailyQuestion>("/daily-question"),
+  stories: () => apiFetch<{ stories: Story[] }>("/stories"),
+  story: (id: string) => apiFetch<Story>(`/stories/${id}`),
+  entry: (id: string) => apiFetch<EntryStatus>(`/entries/${id}`),
+  createTextEntry: (text: string) =>
+    apiFetch<{ entry_id: string }>("/entries/text", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    }),
+  createAudioEntry: (blob: Blob, durationMs: number) => {
+    const form = new FormData();
+    form.append("file", blob, "entry");
+    form.append("duration_ms", String(Math.round(durationMs)));
+    return apiFetch<{ entry_id: string }>("/entries/audio", { method: "POST", body: form });
+  },
+};

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1,0 +1,20 @@
+import type { Story } from "./api";
+
+/** Minimal display-language helper: match the story's own language (et/en). */
+export function storyLang(story: Story): "et" | "en" {
+  return story.language === "et" ? "et" : "en";
+}
+
+const FORMAT_LABELS: Record<"et" | "en", Record<string, string>> = {
+  en: { song: "song", story: "story", film: "film" },
+  et: { song: "laul", story: "lugu", film: "film" },
+};
+
+export function recommendationText(story: Story): string {
+  const lang = storyLang(story);
+  const format = FORMAT_LABELS[lang][story.recommendation.format] ?? story.recommendation.format;
+  const reason = story.recommendation.reason[lang];
+  return lang === "et"
+    ? `See tahab olla ${format} — ${reason}`
+    : `This wants to be a ${format} — ${reason}`;
+}

--- a/web/src/lib/signature.test.ts
+++ b/web/src/lib/signature.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { TONE_STYLES, toneStyle } from "./signature";
+
+describe("signature spectrum", () => {
+  it("covers all eight tones", () => {
+    expect(Object.keys(TONE_STYLES)).toHaveLength(8);
+  });
+
+  it("falls back to calm for unknown tones", () => {
+    // @ts-expect-error deliberately invalid tone
+    expect(toneStyle("unknown")).toBe(TONE_STYLES.calm);
+  });
+
+  it("every tone has border, text and label", () => {
+    for (const style of Object.values(TONE_STYLES)) {
+      expect(style.border).toMatch(/^border-l-sig-/);
+      expect(style.text).toMatch(/^text-sig-/);
+      expect(style.label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/lib/signature.ts
+++ b/web/src/lib/signature.ts
@@ -1,0 +1,20 @@
+import type { Signature } from "./api";
+
+/** Signature Spectrum mapping (docs/plan/02): tone -> token classes + label. */
+export const TONE_STYLES: Record<
+  Signature["tone"],
+  { border: string; text: string; label: string }
+> = {
+  joy: { border: "border-l-sig-joy", text: "text-sig-joy", label: "joy" },
+  bittersweet: { border: "border-l-sig-bittersweet", text: "text-sig-bittersweet", label: "bittersweet" },
+  grief: { border: "border-l-sig-grief", text: "text-sig-grief", label: "grief" },
+  pride: { border: "border-l-sig-pride", text: "text-sig-pride", label: "pride" },
+  calm: { border: "border-l-sig-calm", text: "text-sig-calm", label: "calm" },
+  longing: { border: "border-l-sig-longing", text: "text-sig-longing", label: "longing" },
+  fear: { border: "border-l-sig-fear", text: "text-sig-fear", label: "fear" },
+  wonder: { border: "border-l-sig-wonder", text: "text-sig-wonder", label: "wonder" },
+};
+
+export function toneStyle(tone: Signature["tone"]) {
+  return TONE_STYLES[tone] ?? TONE_STYLES.calm;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the product's core loop end to end per `docs/plan/01` and the P1.1–P1.4 workstreams in `docs/plan/05`: the user speaks (or types), the distill pipeline turns it into a story with an emotional signature, the Reveal screen develops it, and the Chronicle keeps it.

Stacked on the Phase 0 foundation branch.

## Backend

- **Distill pipeline** (`api/app/pipelines/distill.py`): seed → transcribe → distill → safety → finalize, built on the Phase 0 pipeline-run primitive with per-step cost estimates
- **Prompt assets** (`api/app/prompts/assets/`): `distill@v1` (prime directive: never invent facts; preserve the speaker's idiom; respond in the speaker's language) and `crisis-detect@v1` (gentle support-resources flag, never blocks) — versioned markdown with front-matter + loader, per the doc-06 process
- **Real OpenAI providers** (`api/app/providers/openai.py`): transcription + JSON-mode chat with cost estimates; activated by `FAKE_PROVIDERS=false` + `OPENAI_API_KEY`, no code changes needed. Fake mode returns a deterministic story so the whole loop runs with zero spend
- **Routes**: `POST /api/entries/audio` (multipart, mime/size validation), `POST /api/entries/text` (typing fallback), `GET /api/entries/{id}` (poll status + story), `GET /api/stories`, `GET /api/stories/{id}`, `GET /api/daily-question` (deterministic per user per day, EN+ET, 14 curated universal questions)
- **Budget guardrail** (doc 07): per-user daily entry limit (default 20) with a friendly 429
- **Rule-based format recommendation v1**: emotional tone → recommended format + reason
- Media storage: local disk for dev/test, GCS for deployment, behind one interface

## Frontend

- **Speak screen** (the Booth): full-screen recording with live amber waveform (canvas level meter), elapsed timer, silence micro-prompts ("What happened next?"), 5-min cap, too-short guard, mic-denied → graceful typing fallback, cancel
- **Reveal screen** (the Darkroom): "Developing your story…" breathing dusk state with polling → story develops with the staged reveal animation; signature badge, format recommendation chip, Keep/Share/Gift actions (Share/Gift land in Phase 2/3)
- **Chronicle** (the Library): real stories grouped by month with the Spectrum color strip per month, tone-edged cards, story detail view
- **Tonight**: real daily question (Estonian/English by browser locale), record button → Speak, "last from the shelf" card
- Typed API client with Firebase token attach; crisis support card (Eluliin) on flagged stories

## Verification

- API: 13 tests passing (text + audio loop end to end, auth isolation, mime rejection, prompt render guarantees), ruff + mypy clean
- Web: typecheck + 7 tests passing, production build **94.9 KB gzipped JS** (budget 250 KB)
- Real-provider path requires `OPENAI_API_KEY`; once set, flip `FAKE_PROVIDERS=false` in the deploy env

## Next

Founder acceptance gate per doc 05: use the loop daily and verify outputs feel true (no invented details) before Phase 2 (Song + share pages).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acd5ef0e-0e6a-452e-b522-fd781ae96b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acd5ef0e-0e6a-452e-b522-fd781ae96b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

