### PR TITLE
Deploy tooling: Cloud Shell credential bootstrap + direct deploy script

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,13 +10,32 @@ traffic flip (see `LEGACY.md` and `docs/plan/03`):
 
 Root `firebase.json` / `.firebaserc` remain the **legacy** hosting config.
 
-## Required GitHub Actions secrets
+## One-time credential setup
 
-| Secret | Purpose |
+Open [Google Cloud Console](https://console.cloud.google.com) -> Cloud Shell
+(`>_` icon, top right) and paste:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/vaikmarko/sentimentalapp/main/deploy/setup_deploy_credentials.sh | bash
+```
+
+It creates the `github-deploy` service account with all needed roles and
+prints a JSON key. Paste that JSON as the value of these secrets:
+
+| Where | Secrets |
 |---|---|
-| `GCP_SA_KEY` | service account JSON: Cloud Run deploy + build |
-| `FIREBASE_SA_KEY` | service account JSON: Firebase Hosting deploy |
-| `OPENAI_API_KEY` | passed to Cloud Run; enables real providers |
+| GitHub repo -> Settings -> Secrets and variables -> Actions | `GCP_SA_KEY` = key JSON, `FIREBASE_SA_KEY` = same JSON, `OPENAI_API_KEY` = OpenAI key |
+| [Cursor Dashboard](https://cursor.com/dashboard) -> Cloud Agents -> Secrets (optional, lets agents deploy directly) | same three |
 
 Without the first two, the deploy workflow skips quietly. Without the third,
 the API starts with `FAKE_PROVIDERS=true` (deterministic outputs, zero spend).
+
+## Deploying
+
+- **Automatic:** every push to `main` runs `.github/workflows/deploy.yml`
+  (once GitHub secrets exist). Manual trigger: repo -> Actions -> Deploy ->
+  Run workflow.
+- **From a machine / Cursor agent VM:** `bash deploy/deploy_v2.sh` (or
+  `... api` / `... web` for one surface). Uses `GCP_SA_KEY` env var, a
+  `GOOGLE_APPLICATION_CREDENTIALS` key file, or an existing `gcloud auth
+  login` session; installs gcloud/firebase-tools itself if missing.

--- a/deploy/deploy_v2.sh
+++ b/deploy/deploy_v2.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Deploy Sentimental v2 (API -> Cloud Run, web -> Firebase Hosting) from any
+# machine or Cursor cloud agent VM. Mirrors .github/workflows/deploy.yml.
+#
+# Credentials, one of:
+#   - GCP_SA_KEY env var containing the service-account JSON (Cursor secret), or
+#   - GOOGLE_APPLICATION_CREDENTIALS pointing to a key file, or
+#   - an already-authenticated gcloud (local dev machine).
+#
+# Optional:
+#   OPENAI_API_KEY   enables real providers on Cloud Run (otherwise fake mode)
+#
+# Usage:
+#   bash deploy/deploy_v2.sh          # deploy API + web
+#   bash deploy/deploy_v2.sh api      # API only
+#   bash deploy/deploy_v2.sh web      # web only
+
+set -euo pipefail
+
+PROJECT="sentimental-f95e6"
+REGION="europe-west1"
+API_SERVICE="sentimental-api-v2"
+HOSTING_TARGET="sentimentalapp-test"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-all}"
+
+log() { echo ">>> $*"; }
+
+# --- tooling ---------------------------------------------------------------
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  log "gcloud not found - installing Google Cloud SDK (one-time, ~1 min)"
+  curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir="$HOME" >/dev/null
+  export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+fi
+
+if [[ "$TARGET" != "api" ]] && ! command -v firebase >/dev/null 2>&1; then
+  log "firebase-tools not found - installing"
+  npm install -g firebase-tools >/dev/null
+fi
+
+# --- auth ------------------------------------------------------------------
+
+CLEANUP_KEY=""
+if [[ -n "${GCP_SA_KEY:-}" ]]; then
+  CLEANUP_KEY="$(mktemp /tmp/gcp-key-XXXXXX.json)"
+  printf '%s' "$GCP_SA_KEY" > "$CLEANUP_KEY"
+  export GOOGLE_APPLICATION_CREDENTIALS="$CLEANUP_KEY"
+fi
+trap '[[ -n "$CLEANUP_KEY" ]] && rm -f "$CLEANUP_KEY"' EXIT
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  log "Activating service account from ${GOOGLE_APPLICATION_CREDENTIALS}"
+  gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS" --quiet
+fi
+
+if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' | grep -q .; then
+  echo "ERROR: no Google credentials." >&2
+  echo "Set GCP_SA_KEY (service-account JSON) or run 'gcloud auth login' first." >&2
+  echo "To create the key: run deploy/setup_deploy_credentials.sh in Cloud Shell." >&2
+  exit 1
+fi
+
+gcloud config set project "$PROJECT" --quiet
+
+# --- API -> Cloud Run --------------------------------------------------------
+
+if [[ "$TARGET" == "all" || "$TARGET" == "api" ]]; then
+  FAKE="true"
+  [[ -n "${OPENAI_API_KEY:-}" ]] && FAKE="false"
+  VERSION="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo manual)"
+  log "Deploying API to Cloud Run (${API_SERVICE}, FAKE_PROVIDERS=${FAKE})"
+  gcloud run deploy "$API_SERVICE" \
+    --source "$REPO_ROOT/api" \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --allow-unauthenticated \
+    --set-env-vars "ENVIRONMENT=production,APP_VERSION=${VERSION},STORAGE_MODE=gcs,FAKE_PROVIDERS=${FAKE},OPENAI_API_KEY=${OPENAI_API_KEY:-}" \
+    --quiet
+fi
+
+# --- web -> Firebase Hosting -------------------------------------------------
+
+if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
+  log "Building web app"
+  (cd "$REPO_ROOT/web" && npm ci && npm run build)
+  rm -rf "$REPO_ROOT/deploy/dist"
+  cp -r "$REPO_ROOT/web/dist" "$REPO_ROOT/deploy/dist"
+
+  log "Deploying web to Firebase Hosting (site ${HOSTING_TARGET})"
+  (cd "$REPO_ROOT/deploy" && firebase deploy \
+    --only "hosting:${HOSTING_TARGET}" \
+    --project "$PROJECT" \
+    --non-interactive)
+fi
+
+log "Done. Web: https://${HOSTING_TARGET}.web.app"

--- a/deploy/setup_deploy_credentials.sh
+++ b/deploy/setup_deploy_credentials.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# One-paste setup: run this in Google Cloud Shell (https://console.cloud.google.com
+# -> ">_" Cloud Shell icon, top right). It creates the deploy service account,
+# grants the roles needed for Cloud Run + Firebase Hosting deploys, and prints
+# a JSON key to copy into GitHub / Cursor secrets.
+#
+#   curl -fsSL https://raw.githubusercontent.com/vaikmarko/sentimentalapp/main/deploy/setup_deploy_credentials.sh | bash
+#
+# Idempotent: safe to re-run (re-running creates a fresh key each time).
+
+set -euo pipefail
+
+PROJECT="sentimental-f95e6"
+SA_NAME="github-deploy"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+KEY_FILE="$(mktemp /tmp/deploy-key-XXXXXX.json)"
+
+echo ">>> Using project: ${PROJECT}"
+gcloud config set project "${PROJECT}" --quiet
+
+if ! gcloud iam service-accounts describe "${SA_EMAIL}" >/dev/null 2>&1; then
+  echo ">>> Creating service account ${SA_EMAIL}"
+  gcloud iam service-accounts create "${SA_NAME}" \
+    --display-name "GitHub Actions / Cursor deploy" --quiet
+else
+  echo ">>> Service account ${SA_EMAIL} already exists"
+fi
+
+# One service account covers both Cloud Run (API) and Firebase Hosting (web).
+ROLES=(
+  roles/run.admin
+  roles/cloudbuild.builds.editor
+  roles/iam.serviceAccountUser
+  roles/storage.admin
+  roles/artifactregistry.admin
+  roles/firebasehosting.admin
+  roles/serviceusage.serviceUsageConsumer
+)
+for ROLE in "${ROLES[@]}"; do
+  echo ">>> Granting ${ROLE}"
+  gcloud projects add-iam-policy-binding "${PROJECT}" \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role "${ROLE}" \
+    --condition=None --quiet >/dev/null
+done
+
+echo ">>> Creating JSON key"
+gcloud iam service-accounts keys create "${KEY_FILE}" \
+  --iam-account "${SA_EMAIL}" --quiet
+
+echo
+echo "=================================================================="
+echo "DONE. Copy EVERYTHING between the BEGIN/END lines below (the whole"
+echo "JSON block) and paste it as the value of BOTH secrets:"
+echo
+echo "  1. GitHub -> repo Settings -> Secrets and variables -> Actions:"
+echo "       GCP_SA_KEY       = <the JSON below>"
+echo "       FIREBASE_SA_KEY  = <the same JSON>"
+echo "       OPENAI_API_KEY   = <your OpenAI key>"
+echo
+echo "  2. (optional, lets Cursor agents deploy directly)"
+echo "     cursor.com -> Dashboard -> Cloud Agents -> Secrets: same three."
+echo
+echo "----------------------- BEGIN KEY JSON --------------------------"
+cat "${KEY_FILE}"
+echo "------------------------ END KEY JSON ---------------------------"
+rm -f "${KEY_FILE}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

v2 code is merged to `main` and the Deploy workflow runs, but every deploy is skipped because no cloud credentials exist (`GCP_SA_KEY not configured`, `FIREBASE_SA_KEY not configured`). Previously deploys ran from the founder's laptop where `gcloud`/`firebase` were logged in; cloud agents and GitHub Actions have no such credentials.

## What

- **`deploy/setup_deploy_credentials.sh`** — one-paste script for Google Cloud Shell. Creates the `github-deploy` service account in project `sentimental-f95e6`, grants all roles needed for Cloud Run + Firebase Hosting deploys (one SA covers both `GCP_SA_KEY` and `FIREBASE_SA_KEY`), and prints the JSON key to copy into GitHub Actions secrets and Cursor Cloud Agents secrets. Idempotent.
- **`deploy/deploy_v2.sh`** — direct deploy script mirroring `.github/workflows/deploy.yml`. Works from a Cursor cloud agent VM or any machine: installs gcloud/firebase-tools if missing, authenticates from `GCP_SA_KEY` env var / `GOOGLE_APPLICATION_CREDENTIALS` / existing gcloud login, then deploys API to Cloud Run (`sentimental-api-v2`) and web to Firebase Hosting (`sentimentalapp-test`). Supports `api` / `web` / all.
- **`deploy/README.md`** — documents the one-time secret setup and both deploy paths (auto on `main` push, or `bash deploy/deploy_v2.sh`).

## Verified

- Both scripts pass `bash -n`.
- `deploy/deploy_v2.sh` tested in the agent VM: bootstraps the Google Cloud SDK install and fails cleanly with actionable instructions when no credentials are present (expected — this VM has no secrets yet).
- `web` builds clean (95.25 kB gzip JS, PWA precache generated).

## After merge (one-time, founder)

1. Run the Cloud Shell one-liner from `deploy/README.md`.
2. Add `GCP_SA_KEY`, `FIREBASE_SA_KEY` (same JSON) and `OPENAI_API_KEY` to GitHub Actions secrets → every push to `main` auto-deploys.
3. Optionally add the same three to Cursor Dashboard → Cloud Agents → Secrets so agents can deploy directly with `bash deploy/deploy_v2.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a763f744-016c-4725-85bc-a04d20e4fb32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a763f744-016c-4725-85bc-a04d20e4fb32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

